### PR TITLE
Bugfix : macosのアプリIDとアプリ名が環境ごとに変更されない

### DIFF
--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -159,7 +159,6 @@
 				D07C08DB6F0C2F08918D61B8 /* Pods-Runner.release.xcconfig */,
 				8030B8C6C3901B5BC9283A26 /* Pods-Runner.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -427,6 +426,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.leoleo.githubsearch.flutterGithubSearch$flutterApplicationIdSuffix;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
@@ -553,6 +553,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.leoleo.githubsearch.flutterGithubSearch$flutterApplicationIdSuffix;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -573,6 +574,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.leoleo.githubsearch.flutterGithubSearch$flutterApplicationIdSuffix;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -13,7 +13,9 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>$(flutterAppName)</string>
+	<key>CFBundleDisplayName</key>
+	<string>$(flutterAppName)</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
# issues (任意)
close #33 

# 修正内容 (必須)
- macosのアプリIDとアプリ名が環境ごとに変更する


# refs (任意)
